### PR TITLE
Some RPG cleanup

### DIFF
--- a/rpg/subscribe-model.conf
+++ b/rpg/subscribe-model.conf
@@ -2,22 +2,22 @@ subsystem = AOESW
 component = rpg
 
 subscribe {
-  telemetry = [
-    {
-      subsystem = TCS
-      component = tcsPk
-      name = zenithAngle
-      requiredRate = 2
-    }
+  events = [
+    //NFIRAOS
     {
       subsystem     = NFIRAOS
       component     = lgsTrombone
       name          = sodiumLayer
       requiredRate  = 3.33
     }   
-  ]
-  
-  eventStreams = [
+
+    // TCS
+    {
+      subsystem = TCS
+      component = cmNFIRAOS
+      name = lgsTromboneZenith
+      requiredRate = 2
+    }
     {
       subsystem = TCS
       component = cmNFIRAOS
@@ -27,12 +27,10 @@ subscribe {
     {
       subsystem = TCS
       component = cmNFIRAOS
-      name = pwfsPos
+      name = ngsPos
       requiredRate = 20
     }
-  ]
 
-  events = [
     //CSRO
     {
       subsystem=IRIS


### PR DESCRIPTION
 - pwfsPos is now called ngsPos
 - TCS now publishes a specific zenith angle item for the lgsTrombone
 - we are using events instead of telemetry.